### PR TITLE
nkoder's solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 TODO
 
 # IDE
-.idea
+/.idea/*
+!/.idea/codeStyleSettings.xml
 *.ipr
 *.iml
 *.iws

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <codeStyleSettings language="JAVA">
+          <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+        </codeStyleSettings>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,8 @@ dependencies {
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'org.codehaus.groovy:groovy:2.4.7'
     testCompile 'cglib:cglib:3.2.2'
-    
+
+    testCompile 'org.assertj:assertj-core:3.6.2'
+    testCompile 'pl.pragmatists:JUnitParams:1.0.5'
+
 }

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/FacebookImageVersion4Nkoder.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/FacebookImageVersion4Nkoder.java
@@ -17,7 +17,17 @@ public class FacebookImageVersion4Nkoder {
     private final static String FACEBOOK_IMAGE_TAG = "og:image";
     private final static int TEN_SECONDS = 10_000;
 
-    public static String extractImageAddressFrom(String pageUrl) {
+    private final String pageUrl;
+
+    public static FacebookImageVersion4Nkoder fromPage(String pageUrl) {
+        return new FacebookImageVersion4Nkoder(pageUrl);
+    }
+
+    private FacebookImageVersion4Nkoder(String pageUrl) {
+        this.pageUrl = pageUrl;
+    }
+
+    public String url() {
         Document document;
         try {
             document = Jsoup.parse(new URL(pageUrl), TEN_SECONDS);
@@ -34,5 +44,4 @@ public class FacebookImageVersion4Nkoder {
         }
         return ogImages.get(0).attr("content");
     }
-
 }

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/FacebookImageVersion4Nkoder.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/FacebookImageVersion4Nkoder.java
@@ -1,0 +1,38 @@
+package com.softwaremill.java_fp_example.contest.nkoder;
+
+import javaslang.collection.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static com.softwaremill.java_fp_example.DefaultImage.DEFAULT_IMAGE;
+
+@Slf4j
+public class FacebookImageVersion4Nkoder {
+
+    private final static String FACEBOOK_IMAGE_TAG = "og:image";
+    private final static int TEN_SECONDS = 10_000;
+
+    public static String extractImageAddressFrom(String pageUrl) {
+        Document document;
+        try {
+            document = Jsoup.parse(new URL(pageUrl), TEN_SECONDS);
+        } catch (IOException e) {
+            log.error("Unable to extract og:image from url {}. Problem: {}", pageUrl, e.getMessage());
+            return DEFAULT_IMAGE;
+        }
+        List<Element> ogImages = List
+                .ofAll(document.head().getElementsByTag("meta"))
+                .filter(e -> FACEBOOK_IMAGE_TAG.equals(e.attr("property")));
+        if (ogImages.isEmpty()) {
+            log.warn("No {} found for blog post {}", FACEBOOK_IMAGE_TAG, pageUrl);
+            return DEFAULT_IMAGE;
+        }
+        return ogImages.get(0).attr("content");
+    }
+
+}

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/FacebookImageVersion4Nkoder.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/FacebookImageVersion4Nkoder.java
@@ -39,9 +39,9 @@ public class FacebookImageVersion4Nkoder {
 
     private Stream<HtmlMetaTag> metaTagsOfPage(String pageUrl) {
         return Try.of(() -> parsePage(pageUrl))
-                .onFailure(throwable -> logParsingError(this.pageUrl, throwable))
-                .toStream()
-                .flatMap(document -> document.metaTags());
+                  .onFailure(throwable -> logParsingError(this.pageUrl, throwable))
+                  .toStream()
+                  .flatMap(document -> document.metaTags());
     }
 
     private Option<String> firstFacebookImageUrlFrom(Stream<HtmlMetaTag> metaTags) {

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/LICENSE.txt
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 nkoder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlDocument.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlDocument.java
@@ -1,0 +1,19 @@
+package com.softwaremill.java_fp_example.contest.nkoder.html;
+
+import javaslang.collection.Stream;
+import org.jsoup.nodes.Document;
+
+public class HtmlDocument {
+
+    private final Document jsoupDocument;
+
+    public HtmlDocument(Document document) {
+        this.jsoupDocument = document;
+    }
+
+    public Stream<HtmlMetaTag> metaTags() {
+        return Stream.of(jsoupDocument.head().getElementsByTag("meta"))
+                .flatMap(elements -> elements)
+                .map(element -> new HtmlMetaTag(element));
+    }
+}

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlDocument.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlDocument.java
@@ -13,7 +13,7 @@ public class HtmlDocument {
 
     public Stream<HtmlMetaTag> metaTags() {
         return Stream.of(jsoupDocument.head().getElementsByTag("meta"))
-                .flatMap(elements -> elements)
-                .map(element -> new HtmlMetaTag(element));
+                     .flatMap(elements -> elements)
+                     .map(element -> new HtmlMetaTag(element));
     }
 }

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlMetaTag.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlMetaTag.java
@@ -2,12 +2,24 @@ package com.softwaremill.java_fp_example.contest.nkoder.html;
 
 import org.jsoup.nodes.Element;
 
+import static java.lang.String.format;
+
 public class HtmlMetaTag {
 
     private final Element jsoupElement;
 
     HtmlMetaTag(Element element) {
+        validate(element);
         this.jsoupElement = element;
+    }
+
+    private void validate(Element element) {
+        if (!element.tagName().equals("meta")) {
+            throw new RuntimeException(format(
+                    "Element has to be a 'meta' tag, but is '%s'.",
+                    element.tagName()
+            ));
+        }
     }
 
     public boolean hasProperty(String propertyToMatch) {

--- a/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlMetaTag.java
+++ b/src/main/java/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlMetaTag.java
@@ -1,0 +1,25 @@
+package com.softwaremill.java_fp_example.contest.nkoder.html;
+
+import org.jsoup.nodes.Element;
+
+public class HtmlMetaTag {
+
+    private final Element jsoupElement;
+
+    HtmlMetaTag(Element element) {
+        this.jsoupElement = element;
+    }
+
+    public boolean hasProperty(String propertyToMatch) {
+        return property().equals(propertyToMatch);
+    }
+
+    public String content() {
+        return jsoupElement.attr("content");
+    }
+
+    private String property() {
+        return jsoupElement.attr("property");
+    }
+
+}

--- a/src/test/groovy/com/softwaremill/java_fp_example/FacebookImageSpec.groovy
+++ b/src/test/groovy/com/softwaremill/java_fp_example/FacebookImageSpec.groovy
@@ -78,14 +78,11 @@ class FacebookImageSpec extends Specification {
 
     @Unroll
     def "should test nkoder's version with address #postAddress"() {
-        given:
-        FacebookImageVersion4Nkoder facebookImage = new FacebookImageVersion4Nkoder()
-
         when:
-        String imageAddress = facebookImage.extractImageAddressFrom(postAddress)
+        FacebookImageVersion4Nkoder facebookImage = FacebookImageVersion4Nkoder.fromPage(postAddress)
 
         then:
-        imageAddress == expectedImageUrl
+        facebookImage.url() == expectedImageUrl
 
         where:
         postAddress                                                || expectedImageUrl

--- a/src/test/groovy/com/softwaremill/java_fp_example/FacebookImageSpec.groovy
+++ b/src/test/groovy/com/softwaremill/java_fp_example/FacebookImageSpec.groovy
@@ -1,5 +1,6 @@
 package com.softwaremill.java_fp_example
 
+import com.softwaremill.java_fp_example.contest.nkoder.FacebookImageVersion4Nkoder
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -62,7 +63,7 @@ class FacebookImageSpec extends Specification {
     @Unroll
     def "should test Better Javaslang version with address #postAddress"() {
         when:
-        FacebookImageVersion2Javaslang facebookImage = new FacebookImageVersion2Javaslang(postAddress)
+        FacebookImageVersion3BetterJavaslang facebookImage = new FacebookImageVersion3BetterJavaslang(postAddress)
 
         then:
         facebookImage.getUrl() == expectedImageUrl
@@ -74,5 +75,24 @@ class FacebookImageSpec extends Specification {
         "https://twitter.com/softwaremill"                         || DEFAULT_IMAGE
         "http://i-do-not-exist.pl"                                 || DEFAULT_IMAGE
     }
-    
+
+    @Unroll
+    def "should test nkoder's version with address #postAddress"() {
+        given:
+        FacebookImageVersion4Nkoder facebookImage = new FacebookImageVersion4Nkoder()
+
+        when:
+        String imageAddress = facebookImage.extractImageAddressFrom(postAddress)
+
+        then:
+        imageAddress == expectedImageUrl
+
+        where:
+        postAddress                                                || expectedImageUrl
+        "https://softwaremill.com/the-wrong-abstraction-recap/"    || "https://softwaremill.com/images/uploads/2017/02/street-shoe-chewing-gum.0526d557.jpg"
+        "https://softwaremill.com/using-kafka-as-a-message-queue/" || "https://softwaremill.com/images/uploads/2017/02/kmq.93f842cf.png"
+        "https://twitter.com/softwaremill"                         || DEFAULT_IMAGE
+        "http://i-do-not-exist.pl"                                 || DEFAULT_IMAGE
+    }
+
 }

--- a/src/test/groovy/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlDocument_Test.java
+++ b/src/test/groovy/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlDocument_Test.java
@@ -1,0 +1,84 @@
+package com.softwaremill.java_fp_example.contest.nkoder.html;
+
+import org.jsoup.Jsoup;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HtmlDocument_Test {
+
+    @Test
+    public void should_find_no_meta_tags_in_empty_html() {
+        // given
+        HtmlDocument document = new HtmlDocument(Jsoup.parse(
+                ""
+        ));
+
+        // expect
+        assertThat(document.metaTags()).isEmpty();
+    }
+
+    @Test
+    public void should_find_no_meta_tags_in_html_without_head_section() {
+        // given
+        HtmlDocument document = new HtmlDocument(Jsoup.parse(
+                "<html></html>"
+        ));
+
+        // expect
+        assertThat(document.metaTags()).isEmpty();
+    }
+
+    @Test
+    public void should_find_no_meta_tags_in_html_without_them() {
+        // given
+        HtmlDocument document = new HtmlDocument(Jsoup.parse(
+                "<html><head></head></html>"
+        ));
+
+        // expect
+        assertThat(document.metaTags()).isEmpty();
+    }
+
+    @Test
+    public void should_find_meta_tag_among_other_tags() {
+        // given
+        HtmlDocument document = new HtmlDocument(Jsoup.parse(
+                "<html><head>" +
+                        "<link rel=\"icon\" href=\"favicon.ico\"/>" +
+                        "<meta property=\"og:title\" content=\"I'm Meta, The Meta\"/>" +
+                        "</head></html>"
+        ));
+
+        // expect
+        assertThat(document.metaTags())
+                .hasSize(1)
+                .extracting(HtmlMetaTag::content)
+                .contains("I'm Meta, The Meta");
+    }
+
+    @Test
+    public void should_find_multiple_meta_tags() {
+        // given
+        HtmlDocument document = new HtmlDocument(Jsoup.parse(
+                "<html><head>" +
+                        "<meta property=\"og:title\" content=\"Meta, The First\"/>" +
+                        "<meta property=\"og:title\" content=\"duplicate\"/>" +
+                        "<meta property=\"og:title\" content=\"duplicate\"/>" +
+                        "<meta name=\"twitter:card\" value=\"another meta, w/o content\"/>" +
+                        "</head></html>"
+        ));
+
+        // expect
+        assertThat(document.metaTags())
+                .hasSize(4)
+                .extracting(HtmlMetaTag::content)
+                .containsExactly(
+                        "Meta, The First",
+                        "duplicate",
+                        "duplicate",
+                        ""
+                );
+    }
+
+}

--- a/src/test/groovy/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlMetaTag_Test.java
+++ b/src/test/groovy/com/softwaremill/java_fp_example/contest/nkoder/html/HtmlMetaTag_Test.java
@@ -1,0 +1,62 @@
+package com.softwaremill.java_fp_example.contest.nkoder.html;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.jsoup.nodes.Element;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(JUnitParamsRunner.class)
+public class HtmlMetaTag_Test {
+
+    @Test
+    public void should_know_if_it_contains_given_property() {
+        // given
+        HtmlMetaTag htmlMetaTag = new HtmlMetaTag(
+                new Element("meta").attr("property", "og:title")
+        );
+
+        // expect
+        assertThat(htmlMetaTag.hasProperty("og:title")).isTrue();
+        assertThat(htmlMetaTag.hasProperty("og:image")).isFalse();
+    }
+
+    @Parameters(value = {
+            "What a Content!",
+            " whitespaces   are everywhere     ",
+            ""
+    })
+    @Test
+    public void should_provide_its_content(String contentValue) {
+        // given
+        HtmlMetaTag htmlMetaTag = new HtmlMetaTag(
+                new Element("meta").attr("content", contentValue)
+        );
+
+        // expect
+        assertThat(htmlMetaTag.content()).isEqualTo(contentValue);
+    }
+
+    @Test
+    public void should_provide_empty_string_if_content_is_absent() {
+        // given
+        HtmlMetaTag htmlMetaTag = new HtmlMetaTag(
+                new Element("meta")
+        );
+
+        // expect
+        assertThat(htmlMetaTag.content()).isEmpty();
+    }
+
+    @Test
+    public void should_require_real_meta() {
+        assertThatThrownBy(() -> new HtmlMetaTag(
+                new Element("not-a-meta")
+        )).isInstanceOf(RuntimeException.class)
+          .hasMessage("Element has to be a 'meta' tag, but is 'not-a-meta'.");
+    }
+
+}


### PR DESCRIPTION
Hi :-)

In my solution:
1. I wanted to change the behaviour of reference implementation as little as possible. So my "refactoring" does not change original tests neither even log messages ;-P
2. I added a couple of tests afterward because of two reasons. First of all, I wanted to be sure that `jsoupDocument.head().getElementsByTag("meta")` does not throw `NullPointerException` (whether `.head()` can be null or not). Secondly, I'm now fully convinced to existing tests based on let's-hope-never-changing HTML of some external Software Mill blog posts ;-)
3. I decided to stick with Vavr in order to practice it more.
4. I fixed `should test Better Javaslang version with address #postAddress` test to use `FacebookImageVersion3BetterJavaslang` instead of `FacebookImageVersion2Javaslang` for the second time.